### PR TITLE
feat: add gitsubmodule example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 # Ardupilot provides `install-prereqs-ubuntu.sh`, so let's use ubuntu
 FROM ubuntu:22.04
 
-# More releases: https://github.com/ArduPilot/ardupilot/releases
-# Just use the latest one
-ARG RELEASE_TAG=Rover-4.4.0
-
 ## Ardupilot prereqs will hang if we don't disable interactive prompts (installing dependencies/apt and timezone configuration)
 ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
@@ -23,17 +19,16 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER $USER
 ENV HOME=/home/$USER
 WORKDIR $HOME
-
-# Clone ardupilot
-RUN git clone https://github.com/ArduPilot/ardupilot.git
 ENV ARDUPILOT_PATH=/home/$USER/ardupilot
-WORKDIR $ARDUPILOT_PATH
-RUN git checkout ${RELEASE_TAG}
-RUN git submodule update --init --recursive
+ARG ARDUPILOT_PATH_EXTERNAL=ardupilot
 
+## Copy and build ardupilot 
+COPY --chown=$USER $ARDUPILOT_PATH_EXTERNAL $ARDUPILOT_PATH
+WORKDIR $ARDUPILOT_PATH
 RUN Tools/environment_install/install-prereqs-ubuntu.sh -y
 # Add ~/.local/bin to PATH to allow mavproxy.py to be found
 ENV PATH="$PATH:$HOME/.local/bin"
+
 
 ## Build ardupilot components
 RUN ./waf distclean


### PR DESCRIPTION
The changes in this commit cause the docker image build to fail with:
```
99.66 + heading 'Check if we are inside docker environment...'
99.66 + echo '##############################################'
99.66 + echo Check if we are inside docker environment...
99.66 + echo '##############################################'
99.66 + IS_DOCKER=false
99.66 + [[ 0 -eq 1 ]]
99.66 + [[ -f /.dockerenv ]]
99.66 ##############################################
99.66 Check if we are inside docker environment...
99.66 ##############################################
99.66 + grep -Eq '(lxc|docker)' /proc/1/cgroup
99.66 + echo 'Done!'
99.66 + SHELL_LOGIN=.profile
99.66 + false
99.66 + PIP_USER_ARGUMENT=--user
99.66 + PYTHON_VENV_PACKAGE=
99.66 Done!
99.66 + '[' jammy == bookworm ']'
99.66 + '[' jammy == lunar ']'
99.66 + '[' jammy == mantic ']'
99.66 + '[' jammy == noble ']'
99.66 + '[' -n '' ']'
99.66 + pip3 install --user -U pip setuptools wheel
99.93 Requirement already satisfied: pip in /usr/lib/python3/dist-packages (22.0.2)
100.0 Collecting pip
100.1   Downloading pip-24.1.2-py3-none-any.whl (1.8 MB)
100.4      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.8/1.8 MB 6.6 MB/s eta 0:00:00
100.4 Requirement already satisfied: setuptools in /usr/lib/python3/dist-packages (59.6.0)
100.5 Collecting setuptools
100.6   Downloading setuptools-71.0.3-py3-none-any.whl (2.3 MB)
100.8      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.3/2.3 MB 8.6 MB/s eta 0:00:00
100.8 Requirement already satisfied: wheel in /usr/lib/python3/dist-packages (0.37.1)
100.9 Collecting wheel
100.9   Downloading wheel-0.43.0-py3-none-any.whl (65 kB)
100.9      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 65.8/65.8 KB 7.9 MB/s eta 0:00:00
101.0 Installing collected packages: wheel, setuptools, pip
101.0   WARNING: The script wheel is installed in '/home/docker/.local/bin' which is not on PATH.
101.0   Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
101.7   WARNING: The scripts pip, pip3 and pip3.10 are installed in '/home/docker/.local/bin' which is not on PATH.
101.7   Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
101.7 Successfully installed pip-24.1.2 setuptools-71.0.3 wheel-0.43.0
101.7 + '[' '' == true ']'
101.7 + '[' jammy == bookworm ']'
101.7 + '[' jammy == lunar ']'
101.7 + '[' jammy == mantic ']'
101.7 + '[' jammy == noble ']'
101.7 + pip3 install --user -U future lxml pymavlink pyserial MAVProxy pexpect geocoder empy==3.3.4 ptyprocess dronecan flake8 junitparser pygame intelhex
101.9 Collecting future
102.0   Downloading future-1.0.0-py3-none-any.whl.metadata (4.0 kB)
102.0 Requirement already satisfied: lxml in /usr/lib/python3/dist-packages (4.8.0)
102.1 Collecting lxml
102.1   Downloading lxml-5.2.2-cp310-cp310-manylinux_2_28_aarch64.whl.metadata (3.4 kB)
102.1 Collecting pymavlink
102.2   Downloading pymavlink-2.4.41-py3-none-any.whl.metadata (6.2 kB)
102.2 Requirement already satisfied: pyserial in /usr/lib/python3/dist-packages (3.5)
102.4 Collecting MAVProxy
102.4   Downloading MAVProxy-1.8.70-py3-none-any.whl.metadata (1.5 kB)
102.5 Collecting pexpect
102.5   Downloading pexpect-4.9.0-py2.py3-none-any.whl.metadata (2.5 kB)
102.6 Collecting geocoder
102.6   Downloading geocoder-1.38.1-py2.py3-none-any.whl.metadata (14 kB)
102.6 Collecting empy==3.3.4
102.6   Downloading empy-3.3.4.tar.gz (62 kB)
102.6      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 62.9/62.9 kB 4.0 MB/s eta 0:00:00
102.6   Preparing metadata (setup.py): started
102.7   Preparing metadata (setup.py): finished with status 'error'
102.7   error: subprocess-exited-with-error
102.7   
102.7   × python setup.py egg_info did not run successfully.
102.7   │ exit code: 1
102.7   ╰─> [28 lines of output]
102.7       Traceback (most recent call last):
102.7         File "<string>", line 2, in <module>
102.7         File "<pip-setuptools-caller>", line 34, in <module>
102.7         File "/tmp/pip-install-v50vf03_/empy_03a8c0547d304a3386bd9ae6280968fb/setup.py", line 24, in <module>
102.7           setup(
102.7         File "/home/docker/.local/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 184, in setup
102.7           return run_commands(dist)
102.7         File "/home/docker/.local/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 200, in run_commands
102.7           dist.run_commands()
102.7         File "/home/docker/.local/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 970, in run_commands
102.7           self.run_command(cmd)
102.7         File "/home/docker/.local/lib/python3.10/site-packages/setuptools/dist.py", line 974, in run_command
102.7           super().run_command(command)
102.7         File "/home/docker/.local/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 989, in run_command
102.7           cmd_obj.run()
102.7         File "/home/docker/.local/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 321, in run
102.7           self.find_sources()
102.7         File "/home/docker/.local/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 329, in find_sources
102.7           mm.run()
102.7         File "/home/docker/.local/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 555, in run
102.7           self.prune_file_list()
102.7         File "/home/docker/.local/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 621, in prune_file_list
102.7           base_dir = self.distribution.get_fullname()
102.7         File "/home/docker/.local/lib/python3.10/site-packages/setuptools/_core_metadata.py", line 266, in get_fullname
102.7           return _distribution_fullname(self.get_name(), self.get_version())
102.7         File "/home/docker/.local/lib/python3.10/site-packages/setuptools/_core_metadata.py", line 284, in _distribution_fullname
102.7           canonicalize_version(version, strip_trailing_zero=False),
102.7       TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'
102.7       [end of output]
102.7   
102.7   note: This error originates from a subprocess, and is likely not a problem with pip.
102.7 error: metadata-generation-failed
102.7 
102.7 × Encountered error while generating package metadata.
102.7 ╰─> See above for output.
102.7 
102.7 note: This is an issue with the package mentioned above, not pip.
102.7 hint: See above for details.
------
failed to solve: process "/bin/sh -c Tools/environment_install/install-prereqs-ubuntu.sh -y" did not complete successfully: exit code: 1
```